### PR TITLE
Tgb/32 recieve only existing values from db

### DIFF
--- a/src/main/java/com/ibm/csync/impl/Database.java
+++ b/src/main/java/com/ibm/csync/impl/Database.java
@@ -250,15 +250,18 @@ class Database {
 						n++;
 						count++;
 						maxVts = rs.getLong(7);
-						subscription.call(Value.of(
-							Key.of(rs.getString(1)),
-							rs.getString(2),
-							rs.getBoolean(3),
-							rs.getString(4),
-							rs.getString(5),
-							rs.getLong(6),
-							maxVts
-						));
+						//Only return values from the local database if they are not deletes.
+						if (rs.getBoolean(3) == false) {
+							subscription.call(Value.of(
+									Key.of(rs.getString(1)),
+									rs.getString(2),
+									rs.getBoolean(3),
+									rs.getString(4),
+									rs.getString(5),
+									rs.getLong(6),
+									maxVts
+							));
+						}
 					}
 					if (n != GET_LIMIT) return count;
 				}


### PR DESCRIPTION
Resolves #32
Proposed Changes:
*  Should only receive existing values from the cached data in the local db
*  Added tests to ensure the above works as expected

DCO1.1 Signed-off-by: Thomas Boop <tgboop@us.ibm.com>